### PR TITLE
db/migrations add database migration files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+pullmysql:
+	docker pull mysql:8.0
+
+runmysql:
+	docker run --name notifier-mysql -p 33060:3306 -e MYSQL_ROOT_PASSWORD=password -d mysql:8.0
+
+createdb:
+	docker exec -i notifier-mysql mysql -uroot -ppassword  <<< "CREATE DATABASE notifier_db; USE notifier_db;" 2> /dev/null
+
+dropdb:
+	docker exec -i notifier-mysql mysql -uroot -ppassword  <<< "DROP DATABASE notifier_db;" 2> /dev/null
+
+up:
+	migrate -path db/migrations -database "mysql://root:password@tcp(localhost:33060)/notifier_db" -verbose up
+
+down: 
+	migrate -path db/migrations -database "mysql://root:password@tcp(localhost:33060)/notifier_db" -verbose down
+
+.PHONY: pullmysql runmysql createdb dropdb up down

--- a/db/migrations/000001_init_schema.down.sql
+++ b/db/migrations/000001_init_schema.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS notification_events_queue;
+DROP TABLE IF EXISTS followers;
+DROP TABLE IF EXISTS notifications;
+DROP TABLE IF EXISTS notification_states;
+DROP TABLE IF EXISTS users;

--- a/db/migrations/000001_init_schema.up.sql
+++ b/db/migrations/000001_init_schema.up.sql
@@ -1,0 +1,47 @@
+CREATE TABLE `notifications` (
+  `uuid` varchar(255) PRIMARY KEY,
+  `user_uuid` varchar(255),
+  `message` varchar(255) NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `notification_events_queue` (
+  `uuid` varchar(255) PRIMARY KEY,
+  `notification_uuid` varchar(255) NOT NULL,
+  `follower_uuid` varchar(255) NOT NULL,
+  `state_uuid` varchar(255) NOT NULL,
+  `attempts` int
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `notification_states` (
+  `uuid` varchar(255) PRIMARY KEY,
+  `state` enum('pending','delivered','failed') NOT NULL,
+  `message` varchar(255),
+  `requested_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `completed_at` datetime
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `users` (
+  `uuid` varchar(255) PRIMARY KEY,
+  `name` varchar(255),
+  `url` varchar(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `followers` (
+  `uuid` varchar(255) PRIMARY KEY,
+  `user_uuid` varchar(255),
+  `follower_uuid` varchar(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+ALTER TABLE `followers` ADD FOREIGN KEY (`user_uuid`) REFERENCES `users` (`uuid`);
+
+ALTER TABLE `followers` ADD FOREIGN KEY (`follower_uuid`) REFERENCES `users` (`uuid`);
+
+ALTER TABLE `notification_events_queue` ADD FOREIGN KEY (`notification_uuid`) REFERENCES `notifications` (`uuid`);
+
+ALTER TABLE `notification_events_queue` ADD FOREIGN KEY (`state_uuid`) REFERENCES `notification_states` (`uuid`);
+
+ALTER TABLE `notification_events_queue` ADD FOREIGN KEY (`follower_uuid`) REFERENCES `followers` (`uuid`);
+
+ALTER TABLE `notifications` ADD FOREIGN KEY (`user_uuid`) REFERENCES `users` (`uuid`);

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dhij/go-notifier
+
+go 1.20


### PR DESCRIPTION
This PR adds migration files to create tables along with relevant commands under the Makefile to run mysql container, create & drop database, bring the tables up & down using `golang-migrate`.