### PR TITLE
temporarily remove dbsource env variable

### DIFF
--- a/cmd/grpcsvc/Dockerfile
+++ b/cmd/grpcsvc/Dockerfile
@@ -1,12 +1,11 @@
 FROM golang:1.20-alpine AS builder
-ENV DB_SOURCE "root:password@tcp(mysql:3306)/notifier_db"
 
 WORKDIR /build/
 
 COPY . .
 RUN go mod download
 
-RUN DB_SOURCE=${DB_SOURCE} CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" github.com/dhij/go-notifier/cmd/grpcsvc
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-s -w" github.com/dhij/go-notifier/cmd/grpcsvc
 
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags "-s -w" -tags "mysql" \
     github.com/golang-migrate/migrate/v4/cmd/migrate@v4.16.2

--- a/cmd/grpcsvc/main.go
+++ b/cmd/grpcsvc/main.go
@@ -12,6 +12,7 @@ import (
 func main() {
 	var (
 		dbDriver = "mysql"
+		// if you are running the mysql container locally without docker-compose, use dbSource = "root:password@tcp(localhost:33060)/notifier_db"
 		dbSource = "root:password@tcp(mysql:3306)/notifier_db"
 	)
 

--- a/cmd/grpcsvc/main.go
+++ b/cmd/grpcsvc/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"log"
-	"os"
 
 	"github.com/dhij/go-notifier/internal/grpcsvc"
 	_ "github.com/go-sql-driver/mysql"
@@ -13,12 +12,8 @@ import (
 func main() {
 	var (
 		dbDriver = "mysql"
-		dbSource = os.Getenv("DB_SOURCE")
+		dbSource = "root:password@tcp(mysql:3306)/notifier_db"
 	)
-
-	if dbSource == "" {
-		dbSource = "root:password@tcp(localhost:33060)/notifier_db"
-	}
 
 	db, err := sql.Open(dbDriver, dbSource)
 	if err != nil {


### PR DESCRIPTION
For some reason i am not able to read the env variable with `os.Getenv("DB_SOURCE")`. I will store the db source for use within the docker network for the time being.